### PR TITLE
Update settings.kts to pause prod deployments by default

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -296,7 +296,7 @@ object DeployDev : BuildType({
 
 object DeployProd : BuildType({
     name = "Deploy to Prod"
-
+    paused = true
     maxRunningBuilds = 1
     type = BuildTypeSettings.Type.DEPLOYMENT
     enablePersonalBuilds = false


### PR DESCRIPTION
as the setup instructions and cassius config only defines DEV by default.